### PR TITLE
Fix for  vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "open": "0.0.5",
     "os-locale": "1.4.0",
     "progress": "^1.1.8",
-    "request": "2.11.4",
+    "request": "2.74.0",
     "semver": "4.3.6",
     "tabtab": "0.0.2",
     "underscore": "1.8.0",


### PR DESCRIPTION
fh-fhc currently has a 2 vulnerable dependency, introducing 2 different types of known vulnerabilities.

This PR fixes one vulnerable dependency, introducing [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/feedhenry/fh-fhc) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `moment` dependency as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)